### PR TITLE
Installed vault-cli python executable

### DIFF
--- a/python/python-base.Dockerfile
+++ b/python/python-base.Dockerfile
@@ -8,6 +8,10 @@ FROM ubuntu:22.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
+# hadolint ignore=DL3022
+COPY --from=quay.io/mynth/docker-vault-cli:python \
+    /dist /
+
 RUN useradd --create-home --shell /bin/bash monty
 
 # hadolint ignore=DL3008

--- a/python/python-dev.Dockerfile
+++ b/python/python-dev.Dockerfile
@@ -8,6 +8,10 @@ FROM ubuntu:22.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
+# hadolint ignore=DL3022
+COPY --from=quay.io/mynth/docker-vault-cli:python \
+    /dist /
+
 RUN useradd --create-home --shell /bin/bash monty
 
 # hadolint ignore=DL3008


### PR DESCRIPTION
`vault-cli` is now available to call from within our python containers