### PR TITLE
Allowing node modules to be built

### DIFF
--- a/examples/node-18/package-lock.json
+++ b/examples/node-18/package-lock.json
@@ -12,6 +12,7 @@
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
         "autoprefixer": "10.4.14",
+        "blake2": "^5.0.0",
         "eslint": "8.40.0",
         "eslint-config-next": "13.4.2",
         "next": "13.4.2",
@@ -778,6 +779,18 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/blake2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/blake2/-/blake2-5.0.0.tgz",
+      "integrity": "sha512-MLpq1DwBB9rC0IHuRc2gXLEAeNNTTYHEtvYCA5lK4RmoUPRmQLSLQrwgJvou62BvH9KP7whe8n+xxw45++fnYg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.17.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/bplist-parser": {
@@ -2785,6 +2798,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.6",

--- a/examples/node-18/package.json
+++ b/examples/node-18/package.json
@@ -13,6 +13,7 @@
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
     "autoprefixer": "10.4.14",
+    "blake2": "^5.0.0",
     "eslint": "8.40.0",
     "eslint-config-next": "13.4.2",
     "next": "13.4.2",

--- a/node-18/node-base.Dockerfile
+++ b/node-18/node-base.Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/nodejs && \
     rm node-v18.18.2-linux-x64.tar.xz
 
 ENV PATH $PATH:/usr/local/lib/nodejs/node-v18.18.2-linux-x64/bin
-RUN npm install -g npm@10.6.0
+RUN npm install -g npm@10.7.0
 
 FROM ubuntu:22.04
 COPY --from=build /tini /sbin/tini

--- a/node-18/node-dev.Dockerfile
+++ b/node-18/node-dev.Dockerfile
@@ -43,7 +43,6 @@ RUN corepack enable && \
         build-essential \
         python3.11 \
         python3.11-dev \
-        xz-utils \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/node-18/node-dev.Dockerfile
+++ b/node-18/node-dev.Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/nodejs && \
     rm node-v18.18.2-linux-x64.tar.xz
 
 ENV PATH $PATH:/usr/local/lib/nodejs/node-v18.18.2-linux-x64/bin
-RUN npm install -g npm@10.6.0 && \
+RUN npm install -g npm@10.7.0 && \
     npm config set update-notifier false
 
 FROM ubuntu:22.04

--- a/node-18/node-dev.Dockerfile
+++ b/node-18/node-dev.Dockerfile
@@ -35,7 +35,19 @@ RUN useradd --create-home --shell /bin/bash noddy && \
 COPY --from=build /usr/local/lib/nodejs /usr/local/lib/nodejs
 ENV PATH /app/node_modules/.bin:/usr/local/lib/nodejs/node-v18.18.2-linux-x64/bin:$PATH
 
-RUN corepack enable && corepack prepare yarn@stable --activate
+# hadolint ignore=DL3008
+RUN corepack enable && \
+    corepack prepare yarn@stable --activate && \
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        python3.11 \
+        python3.11-dev \
+        xz-utils \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm install -g node-gyp@v10.1.0
 
 USER noddy
 ENV NODE_ENV production

--- a/node-18/node-dev.Dockerfile
+++ b/node-18/node-dev.Dockerfile
@@ -46,7 +46,9 @@ RUN corepack enable && \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/python3.11 /usr/bin/python && \
     npm install -g node-gyp@v10.1.0
 
 USER noddy
 ENV NODE_ENV production
+ENV PYTHON=/usr/bin/python


### PR DESCRIPTION
Some npm packages such as [blake2](https://www.npmjs.com/package/blake2) require Python and other build dependencies. This PR modifies the `quay.io/mynth/node:18-dev` image to allow installation of these libraries.