### PR TITLE
Set up `pnpm` in node 22 container

### DIFF
--- a/node-22/node-dev.Dockerfile
+++ b/node-22/node-dev.Dockerfile
@@ -37,7 +37,7 @@ ENV PATH=/app/node_modules/.bin:/usr/local/lib/nodejs/node-v22.13.1-linux-x64/bi
 
 # hadolint ignore=DL3008
 RUN corepack enable && \
-    corepack prepare yarn@stable --activate && \
+    corepack prepare pnpm@latest --activate && \
     apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         python3.12 \
@@ -50,4 +50,4 @@ RUN corepack enable && \
     npm install -g node-gyp@v11.0.0
 
 USER noddy
-ENV NODE_ENV=production
+ENV NODE_ENV=development


### PR DESCRIPTION
In this PR I propose two changes:

- Setting up `pnpm` via corepack (instead of `yarn`, which we never use)
- Setting environment in dev container to `development`, so dev containers are able to build by default