### PR TITLE
Update all images to Ubuntu 26.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository holds the base container images used by Mynth. These
 images are publicly hosted on [Quay](https://quay.io/organization/mynth)
-and can be accessed using the `quay.io/mynth/<name>` registry.
+and can be accessed using the `quay.io/mynth/<name>` registry. All images
+are based on Ubuntu 26.04 LTS.
 
 ## Node
 
@@ -80,7 +81,7 @@ you can access the running web application at `http://localhost:3000/`.
 ## Python
 
 The `python` image is a lightweight and optimized container for running
-Python applications that use `uv`. It comes with Python 3.12 installed.
+Python applications that use `uv`. It comes with Python 3.14 installed.
 Two tags exist for the `python` container:
 
 - quay.io/mynth/python:base

--- a/node-24/node-base.Dockerfile
+++ b/node-24/node-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS build
+FROM ubuntu:26.04 AS build
 
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/local/lib/nodejs && \
 
 ENV PATH=$PATH:/usr/local/lib/nodejs/node-v24.15.0-linux-x64/bin
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 COPY --from=build /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/node-24/node-dev.Dockerfile
+++ b/node-24/node-dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS build
+FROM ubuntu:26.04 AS build
 
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -21,7 +21,7 @@ ENV PATH=$PATH:/usr/local/lib/nodejs/node-v24.15.0-linux-x64/bin
 RUN npm install -g corepack@0.34.7 && \
     npm config set update-notifier false
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 COPY --from=build /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/python/python-base.Dockerfile
+++ b/python/python-base.Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:24.04 AS tini
+FROM ubuntu:26.04 AS tini
 
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
@@ -12,11 +12,11 @@ RUN useradd --create-home --shell /bin/bash monty
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends python3.12 && \
+    apt-get install -y --no-install-recommends python3.14 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3.12 /usr/bin/python3 && \
-    ln -s /usr/bin/python3.12 /usr/bin/python
+    ln -s /usr/bin/python3.14 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.14 /usr/bin/python
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8

--- a/python/python-dev.Dockerfile
+++ b/python/python-dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS tini
+FROM ubuntu:26.04 AS tini
 
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -6,7 +6,7 @@ RUN chmod +x /tini
 
 FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
@@ -16,11 +16,11 @@ RUN useradd --create-home --shell /bin/bash monty
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends python3.12 && \
+    apt-get install -y --no-install-recommends python3.14 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3.12 /usr/bin/python3 && \
-    ln -s /usr/bin/python3.12 /usr/bin/python
+    ln -s /usr/bin/python3.14 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.14 /usr/bin/python
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary

Rebases all base images from Ubuntu 24.04 LTS to **Ubuntu 26.04 LTS** (Resolute Raccoon):

- `node-24/node-base.Dockerfile`, `node-24/node-dev.Dockerfile`: `FROM ubuntu:24.04` → `ubuntu:26.04` (build **and** runtime stages)
- `python/python-base.Dockerfile`, `python/python-dev.Dockerfile`: `FROM ubuntu:24.04` → `ubuntu:26.04` (tini + runtime stages)
- `python3.12` does not exist in the 26.04 archives (26.04 ships Python 3.14), so the python images now install `python3.14` and the `/usr/bin/python` + `/usr/bin/python3` symlinks point to it
- README: “comes with Python 3.12” → 3.14, and documented that all images are based on Ubuntu 26.04 LTS

Unchanged on purpose:

- `runs-on: ubuntu-latest` in the workflows is GitHub-hosted CI infrastructure, not our published images
- `Makefile` and examples contain no Ubuntu version references; `requires-python = ">=3.12"` remains satisfied by 3.14

## Validation (local, Docker 29.6.2)

- `hadolint`: all 6 Dockerfiles pass
- `make all` (all 6 targets): builds green
- Runtime checks inside built images — `PRETTY_NAME="Ubuntu 26.04 LTS"` for `node:24-base`, `node:24-dev`, `python:base`, `python:dev`, `node-24-example`, `python-example`; `node v24.15.0`, `pnpm 11.22.0`, `turbo 2.9.10`, `Python 3.14.4`, `uv 0.12.5`, `poe 0.48.0`
- Smoke tests (same as CI): `node-24-example` serves HTTP on :3000, `python-example` returns `{"Hello":"Containers"}` on :8000