### PR TITLE
Use fnm to install Node.js in node images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ node.js applications. Two tags exist for the `node` container:
 - quay.io/mynth/node:26-base
 - quay.io/mynth/node:26-dev
 
+Node.js is installed and managed with
+[fnm](https://github.com/Schniz/fnm) (Fast Node Manager). The images
+ship the `fnm` binary with Node.js 26 set as the default version under
+`/usr/local/share/fnm`.
+
 ### Usage
 
 To use a `node` image, create a `Dockerfile` in your project directory

--- a/node-26/node-base.Dockerfile
+++ b/node-26/node-base.Dockerfile
@@ -1,23 +1,30 @@
 FROM ubuntu:26.04 AS build
 
+ARG FNM_VERSION=1.39.0
+ARG NODE_VERSION=26.7.0
+# Keep this path identical in all stages: fnm stores the default-version
+# alias as an absolute symlink, so it must resolve to the same location.
+ENV FNM_DIR=/usr/local/share/fnm
+
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+ADD https://github.com/Schniz/fnm/releases/download/v${FNM_VERSION}/fnm-linux.zip .
+
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends xz-utils && \
+    apt-get install -y --no-install-recommends ca-certificates unzip && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    unzip fnm-linux.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/fnm && \
+    rm fnm-linux.zip
 
-ADD https://nodejs.org/dist/v26.7.0/node-v26.7.0-linux-x64.tar.xz .
+RUN fnm install ${NODE_VERSION} && \
+    fnm default ${NODE_VERSION}
 
-RUN mkdir -p /usr/local/lib/nodejs && \
-    tar -xJf node-v26.7.0-linux-x64.tar.xz && \
-    mv node-v26.7.0-linux-x64 /usr/local/lib/nodejs && \
-    rm node-v26.7.0-linux-x64.tar.xz
-
-ENV PATH=$PATH:/usr/local/lib/nodejs/node-v26.7.0-linux-x64/bin
+ENV PATH=$FNM_DIR/aliases/default/bin:$PATH
 
 FROM ubuntu:26.04
 COPY --from=build /tini /sbin/tini
@@ -34,8 +41,10 @@ RUN apt-get update -qq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /usr/local/lib/nodejs /usr/local/lib/nodejs
-ENV PATH=/app/node_modules/.bin:/usr/local/lib/nodejs/node-v26.7.0-linux-x64/bin:$PATH
+COPY --from=build /usr/local/bin/fnm /usr/local/bin/fnm
+COPY --from=build /usr/local/share/fnm /usr/local/share/fnm
+ENV FNM_DIR=/usr/local/share/fnm
+ENV PATH=/app/node_modules/.bin:$FNM_DIR/aliases/default/bin:$PATH
 
 # hadolint ignore=DL3066
 USER noddy

--- a/node-26/node-dev.Dockerfile
+++ b/node-26/node-dev.Dockerfile
@@ -1,23 +1,30 @@
 FROM ubuntu:26.04 AS build
 
+ARG FNM_VERSION=1.39.0
+ARG NODE_VERSION=26.7.0
+# Keep this path identical in all stages: fnm stores the default-version
+# alias as an absolute symlink, so it must resolve to the same location.
+ENV FNM_DIR=/usr/local/share/fnm
+
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+ADD https://github.com/Schniz/fnm/releases/download/v${FNM_VERSION}/fnm-linux.zip .
+
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends xz-utils libatomic1 && \
+    apt-get install -y --no-install-recommends ca-certificates unzip libatomic1 && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    unzip fnm-linux.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/fnm && \
+    rm fnm-linux.zip
 
-ADD https://nodejs.org/dist/v26.7.0/node-v26.7.0-linux-x64.tar.xz .
+RUN fnm install ${NODE_VERSION} && \
+    fnm default ${NODE_VERSION}
 
-RUN mkdir -p /usr/local/lib/nodejs && \
-    tar -xJf node-v26.7.0-linux-x64.tar.xz && \
-    mv node-v26.7.0-linux-x64 /usr/local/lib/nodejs && \
-    rm node-v26.7.0-linux-x64.tar.xz
-
-ENV PATH=$PATH:/usr/local/lib/nodejs/node-v26.7.0-linux-x64/bin
+ENV PATH=$FNM_DIR/aliases/default/bin:$PATH
 RUN npm install -g corepack@0.35.0 && \
     npm config set update-notifier false
 
@@ -29,9 +36,11 @@ RUN useradd --create-home --shell /bin/bash noddy && \
     mkdir /app && \
     chown -R noddy:noddy /app
 
-COPY --from=build /usr/local/lib/nodejs /usr/local/lib/nodejs
+COPY --from=build /usr/local/bin/fnm /usr/local/bin/fnm
+COPY --from=build /usr/local/share/fnm /usr/local/share/fnm
+ENV FNM_DIR=/usr/local/share/fnm
 ENV PNPM_HOME=/home/noddy/.local/share/pnpm
-ENV PATH=$PNPM_HOME:/app/node_modules/.bin:/usr/local/lib/nodejs/node-v26.7.0-linux-x64/bin:$PATH
+ENV PATH=$PNPM_HOME:/app/node_modules/.bin:$FNM_DIR/aliases/default/bin:$PATH
 
 # Node.js 26 requires libatomic.so.1, so apt runs before corepack/npm
 # hadolint ignore=DL3008


### PR DESCRIPTION
## Summary
- Install Node.js with [fnm](https://github.com/Schniz/fnm) (Fast Node Manager) v1.39.0 instead of `ADD`-ing the `nodejs.org` dist tarball and extracting it with `tar`. (The tini download from GitHub is unchanged.)
- `fnm install 26.7.0 && fnm default 26.7.0` installs Node under `/usr/local/share/fnm`. The path is identical in the build and final stages because fnm stores the `default` alias as an **absolute** symlink, so it must resolve at the same location.
- Both images now ship the `fnm` binary (e.g. `fnm ls` works out of the box; root can install additional versions).
- Build-stage dependency changes: dropped `xz-utils` (fnm extracts the Node tarball itself — verified), added `ca-certificates` (needed for fnm's HTTPS download from nodejs.org) and `unzip` (to unpack the fnm release zip). The dev build stage keeps `libatomic1` because it executes Node (`npm install -g corepack`).
- Behavior parity preserved: Node 26.7.0, same `PATH` ordering (`/app/node_modules/.bin` first, Node bin after), tini entrypoint, corepack/pnpm/node-gyp/turbo pins, `npm config set update-notifier false`, `NODE_ENV` values.
- README: document that Node.js is installed and managed via fnm.

## Verification
- Built `quay.io/mynth/node:26-base` and `quay.io/mynth/node:26-dev` locally.
- Base smoke test: runs as `noddy`; `node -v` → v26.7.0; `npm -v` → 11.19.0; `fnm ls` → `* v26.7.0 default`; `which node` → `/usr/local/share/fnm/aliases/default/bin/node`; `update-notifier` → false.
- Dev smoke test: `corepack` 0.35.0, `pnpm` 11.22.0, `turbo` 2.10.10, `node-gyp` 13.0.1.
- End-to-end: built `examples/node-26` against the locally built images (exercises corepack/pnpm/tsx) and ran the container — prints `hello` and exits 0.