### PR TITLE
Install Python with uv instead of apt-get in python images

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ you can access the running web application at `http://localhost:3000/`.
 ## Python
 
 The `python` image is a lightweight and optimized container for running
-Python applications that use `uv`. It comes with Python 3.14 installed.
-Two tags exist for the `python` container:
+Python applications that use `uv`. It comes with Python 3.14 installed
+by `uv python install` as a standalone managed CPython build, instead of
+Ubuntu's apt package. Two tags exist for the `python` container:
 
 - quay.io/mynth/python:base
 - quay.io/mynth/python:dev

--- a/python/python-base.Dockerfile
+++ b/python/python-base.Dockerfile
@@ -4,25 +4,33 @@ ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
+
+FROM ubuntu:26.04 AS python
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+
+RUN uv python install 3.14.7 --no-cache
+
 FROM ubuntu:26.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
-RUN useradd --create-home --shell /bin/bash monty
+COPY --from=python /opt/uv/python /opt/uv/python
 
-# hadolint ignore=DL3008
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends python3.14 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3.14 /usr/bin/python3 && \
-    ln -s /usr/bin/python3.14 /usr/bin/python
+RUN ln -s /opt/uv/python/cpython-3.14-*/bin/python3.14 /usr/local/bin/python3.14 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python3 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python && \
+    useradd --create-home --shell /bin/bash monty
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
 ENV PATH=/app/.venv/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # hadolint ignore=DL3066
 USER monty

--- a/python/python-dev.Dockerfile
+++ b/python/python-dev.Dockerfile
@@ -6,30 +6,35 @@ RUN chmod +x /tini
 
 FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
 
+FROM ubuntu:26.04 AS python
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+
+RUN uv python install 3.14.7 --no-cache
+
 FROM ubuntu:26.04
 COPY --from=tini /tini /sbin/tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=uv /uv /uvx /usr/local/bin/
 
-RUN useradd --create-home --shell /bin/bash monty
+COPY --from=python /opt/uv/python /opt/uv/python
 
-# hadolint ignore=DL3008
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends python3.14 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3.14 /usr/bin/python3 && \
-    ln -s /usr/bin/python3.14 /usr/bin/python
+RUN ln -s /opt/uv/python/cpython-3.14-*/bin/python3.14 /usr/local/bin/python3.14 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python3 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python && \
+    useradd --create-home --shell /bin/bash monty
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
 ENV PATH=/app/.venv/bin:$PATH
-ENV UV_PYTHON_PREFERENCE=only-system
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=only-managed
 
-# hadolint ignore=DL3008
 RUN UV_TOOL_DIR=/opt/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install poethepoet==0.48.0
 


### PR DESCRIPTION
## Summary
- Install CPython **3.14.7** via `uv python install` instead of `apt-get install python3.14` in both `python:base` and `python:dev`
- New multi-stage layout: a `python` stage (Ubuntu + uv copied from `ghcr.io/astral-sh/uv:0.12.5`) installs the standalone managed build into `/opt/uv/python`; the final `base` stage copies **only** the interpreter tree, so `base` stays uv-free (matching the existing dev/base split)
- `/usr/local/bin/python3.14` / `python3` / `python` convenience symlinks now point at the uv-managed interpreter (via uv's stable `cpython-3.14-*` symlink, so patch bumps only touch the `uv python install` line)
- `dev`: added `UV_PYTHON_INSTALL_DIR=/opt/uv/python` and switched `UV_PYTHON_PREFERENCE` from `only-system` to `only-managed` so `uv sync` / `uv tool` resolve the managed interpreter
- README updated to note Python is installed by `uv python install` (standalone managed build, not the Ubuntu package)

## Compatibility note
Venvs created in `dev` (e.g. by `install-uv-app`) symlink to `/opt/uv/python/cpython-3.14.7-*/bin/python3.14`; `base` provides that exact path since both images are built from the same pinned version. Pair `dev`/`base` from the same tag/commit as before.

## Validation
- `hadolint` (v2.12.0, same major as CI action) — clean on both Dockerfiles
- `make build-python-base`, `make build-python-dev`, `make build-python-example` — all pass
- `base`: `python3 -V` → Python 3.14.7, `uv` absent (as before)
- `dev`: Python 3.14.7, `uv 0.12.5`, `poe 0.48.0`, `install-uv-app` present
- Example container serves `{"Hello":"Containers"}` on `:8000`