### PR TITLE
Add worker image combining node and python toolchains

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Publish container
         run: |
           TAG=$(git rev-parse --short HEAD)
-          docker tag quay.io/mynth/worker:26 quay.io/mynth/worker:26-$TAG
-          docker push quay.io/mynth/worker:26
-          docker push quay.io/mynth/worker:26-$TAG
+          docker tag quay.io/mynth/worker:dev quay.io/mynth/worker:dev-$TAG
+          docker push quay.io/mynth/worker:dev
+          docker push quay.io/mynth/worker:dev-$TAG
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,28 +67,3 @@ jobs:
           docker push quay.io/mynth/python:base-$TAG
           docker push quay.io/mynth/python:dev-$TAG
         if: github.ref == 'refs/heads/main'
-
-  publish-worker:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Login to Quay.io
-        uses: docker/login-action@v4.6.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_ID }}
-          password: ${{ secrets.QUAY_PW }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.1
-
-      - name: Build worker container
-        run: make build-worker
-
-      - name: Publish container
-        run: |
-          TAG=$(git rev-parse --short HEAD)
-          docker tag quay.io/mynth/worker:dev quay.io/mynth/worker:dev-$TAG
-          docker push quay.io/mynth/worker:dev
-          docker push quay.io/mynth/worker:dev-$TAG
-        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,3 +67,28 @@ jobs:
           docker push quay.io/mynth/python:base-$TAG
           docker push quay.io/mynth/python:dev-$TAG
         if: github.ref == 'refs/heads/main'
+
+  publish-worker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Login to Quay.io
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_PW }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Build worker container
+        run: make build-worker
+
+      - name: Publish container
+        run: |
+          TAG=$(git rev-parse --short HEAD)
+          docker tag quay.io/mynth/worker:26 quay.io/mynth/worker:26-$TAG
+          docker push quay.io/mynth/worker:26
+          docker push quay.io/mynth/worker:26-$TAG
+        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -26,23 +26,20 @@ jobs:
       run: make worker
 
     - name: Run worker-example task
-      run: |
-        docker run --rm worker-example | tee worker-example.log
-        grep -q "worker task completed" worker-example.log
+      run: docker run --rm worker-example
 
     - name: Check worker tooling is available
       run: |
-        docker run --rm quay.io/mynth/worker:dev node --version
-        docker run --rm quay.io/mynth/worker:dev npm --version
-        docker run --rm quay.io/mynth/worker:dev pnpm --version
-        docker run --rm quay.io/mynth/worker:dev fnm --version
-        docker run --rm quay.io/mynth/worker:dev fnm ls
-        docker run --rm quay.io/mynth/worker:dev python --version
-        docker run --rm quay.io/mynth/worker:dev uv --version
-        docker run --rm quay.io/mynth/worker:dev uvx --version
-        docker run --rm quay.io/mynth/worker:dev poe --version
+        docker run --rm quay.io/mynth/worker:dev sh -c '
+          node --version && npm --version && pnpm --version &&
+          fnm --version && fnm ls &&
+          python --version && uv --version && uvx --version && poe --version
+        '
 
     - name: Check worker user can modify its environment
       run: |
-        docker run --rm quay.io/mynth/worker:dev sudo -n whoami
-        docker run --rm quay.io/mynth/worker:dev sh -c 'sudo -n apt-get update -qq && sudo -n apt-get install -y --no-install-recommends jq && jq --version'
+        docker run --rm quay.io/mynth/worker:dev sh -c '
+          sudo -n apt-get update -qq &&
+          sudo -n apt-get install -y --no-install-recommends jq &&
+          jq --version
+        '

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -32,12 +32,12 @@ jobs:
 
     - name: Check worker tooling is available
       run: |
-        docker run --rm quay.io/mynth/worker:26 node --version
-        docker run --rm quay.io/mynth/worker:26 npm --version
-        docker run --rm quay.io/mynth/worker:26 pnpm --version
-        docker run --rm quay.io/mynth/worker:26 fnm --version
-        docker run --rm quay.io/mynth/worker:26 fnm ls
-        docker run --rm quay.io/mynth/worker:26 python --version
-        docker run --rm quay.io/mynth/worker:26 uv --version
-        docker run --rm quay.io/mynth/worker:26 uvx --version
-        docker run --rm quay.io/mynth/worker:26 poe --version
+        docker run --rm quay.io/mynth/worker:dev node --version
+        docker run --rm quay.io/mynth/worker:dev npm --version
+        docker run --rm quay.io/mynth/worker:dev pnpm --version
+        docker run --rm quay.io/mynth/worker:dev fnm --version
+        docker run --rm quay.io/mynth/worker:dev fnm ls
+        docker run --rm quay.io/mynth/worker:dev python --version
+        docker run --rm quay.io/mynth/worker:dev uv --version
+        docker run --rm quay.io/mynth/worker:dev uvx --version
+        docker run --rm quay.io/mynth/worker:dev poe --version

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-worker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.1
+
+    - name: Check worker/worker.Dockerfile
+      uses: hadolint/hadolint-action@v3.4.0
+      with:
+        dockerfile: worker/worker.Dockerfile
+
+    - name: Check examples/worker/Dockerfile
+      uses: hadolint/hadolint-action@v3.4.0
+      with:
+        dockerfile: examples/worker/Dockerfile
+
+    - name: Build containers
+      run: make worker
+
+    - name: Run worker-example task
+      run: |
+        docker run --rm worker-example | tee worker-example.log
+        grep -q "worker task completed" worker-example.log
+
+    - name: Check worker tooling is available
+      run: |
+        docker run --rm quay.io/mynth/worker:26 node --version
+        docker run --rm quay.io/mynth/worker:26 npm --version
+        docker run --rm quay.io/mynth/worker:26 pnpm --version
+        docker run --rm quay.io/mynth/worker:26 fnm --version
+        docker run --rm quay.io/mynth/worker:26 fnm ls
+        docker run --rm quay.io/mynth/worker:26 python --version
+        docker run --rm quay.io/mynth/worker:26 uv --version
+        docker run --rm quay.io/mynth/worker:26 uvx --version
+        docker run --rm quay.io/mynth/worker:26 poe --version

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -41,3 +41,8 @@ jobs:
         docker run --rm quay.io/mynth/worker:dev uv --version
         docker run --rm quay.io/mynth/worker:dev uvx --version
         docker run --rm quay.io/mynth/worker:dev poe --version
+
+    - name: Check worker user can modify its environment
+      run: |
+        docker run --rm quay.io/mynth/worker:dev sudo -n whoami
+        docker run --rm quay.io/mynth/worker:dev sh -c 'sudo -n apt-get update -qq && sudo -n apt-get install -y --no-install-recommends jq && jq --version'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-all: node-26 python
+all: node-26 python worker
 node-26: build-node-26-base build-node-26-dev build-node-26-example
 python: build-python-base build-python-dev build-python-example
+worker: build-worker build-worker-example
 
 build-node-26-base:
 	docker build -t quay.io/mynth/node:26-base -f node-26/node-base.Dockerfile node-26
@@ -19,3 +20,9 @@ build-python-dev:
 
 build-python-example:
 	docker build -t python-example examples/python
+
+build-worker:
+	docker build -t quay.io/mynth/worker:26 -f worker/worker.Dockerfile .
+
+build-worker-example:
+	docker build -t worker-example examples/worker

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-python-example:
 	docker build -t python-example examples/python
 
 build-worker:
-	docker build -t quay.io/mynth/worker:26 -f worker/worker.Dockerfile .
+	docker build -t quay.io/mynth/worker:dev -f worker/worker.Dockerfile .
 
 build-worker-example:
 	docker build -t worker-example examples/worker

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ by [`uv`](https://docs.astral.sh/uv/), together with the tooling from
 the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
 `install-uv-app`) plus `build-essential` for native modules:
 
-- quay.io/mynth/worker:26
+- quay.io/mynth/worker:dev
 
 The image is intended for running tasks in an isolated environment, for
 example builds, code generation or scripts that need both ecosystems.
@@ -208,8 +208,8 @@ Run one-off tasks against your project directory by mounting it into
 `/app`:
 
 ``` bash
-docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:26 pnpm install
-docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:26 uv sync
+docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:dev pnpm install
+docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:dev uv sync
 ```
 
 Because both toolchains are available, a single task can use node and
@@ -227,7 +227,7 @@ versions, point `FNM_DIR` at a user-writable location and run the task
 with `fnm exec`:
 
 ``` bash
-docker run --rm -e FNM_DIR=/home/worker/.local/share/fnm quay.io/mynth/worker:26 \
+docker run --rm -e FNM_DIR=/home/worker/.local/share/fnm quay.io/mynth/worker:dev \
   sh -c "fnm install 24 && fnm exec --using=24 node --version"
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
 
 The image is intended for running tasks in an isolated environment, for
 example builds, code generation or scripts that need both ecosystems.
+The `worker` user has passwordless `sudo`, so a task can also modify the
+container environment at runtime, for example installing additional
+packages:
+
+``` bash
+docker run --rm quay.io/mynth/worker:dev sh -c 'sudo apt-get update -qq && sudo apt-get install -y jq && jq --version'
+```
 
 ### Usage
 
@@ -224,7 +231,7 @@ docker run --rm worker-example
 Node.js versions are managed with `fnm`, but `/usr/local/share/fnm` is
 shared and read-only for the `worker` user. To install additional Node.js
 versions, point `FNM_DIR` at a user-writable location and run the task
-with `fnm exec`:
+with `fnm exec`, or install system-wide with `sudo -E fnm install`:
 
 ``` bash
 docker run --rm -e FNM_DIR=/home/worker/.local/share/fnm quay.io/mynth/worker:dev \

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ single container with both toolchains side by side. It ships Node.js 26
 managed by [fnm](https://github.com/Schniz/fnm) and Python 3.14 managed
 by [`uv`](https://docs.astral.sh/uv/), together with the tooling from
 the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
-`install-uv-app`) plus `build-essential` for native modules:
+`install-uv-app`) plus `build-essential` for native modules. A single
+tag exists for the `worker` container:
 
 - quay.io/mynth/worker:dev
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,49 @@ poe format
 Tasks are executed through `uv run`, so they always run in the
 project's virtual environment.
 
+## Worker
+
+The `worker` image combines the `node` and `python` images into a
+single container with both toolchains side by side. It ships Node.js 26
+managed by [fnm](https://github.com/Schniz/fnm) and Python 3.14 managed
+by [`uv`](https://docs.astral.sh/uv/), together with the tooling from
+the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
+`install-uv-app`) plus `build-essential` for native modules:
+
+- quay.io/mynth/worker:26
+
+The image is intended for running tasks in an isolated environment, for
+example builds, code generation or scripts that need both ecosystems.
+
+### Usage
+
+Run one-off tasks against your project directory by mounting it into
+`/app`:
+
+``` bash
+docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:26 pnpm install
+docker run --rm -v "$PWD":/app -w /app quay.io/mynth/worker:26 uv sync
+```
+
+Because both toolchains are available, a single task can use node and
+python together. The example in [examples/worker](examples/worker)
+orchestrates a Python calculation from Node.js:
+
+``` bash
+docker build -t worker-example examples/worker
+docker run --rm worker-example
+```
+
+Node.js versions are managed with `fnm`, but `/usr/local/share/fnm` is
+shared and read-only for the `worker` user. To install additional Node.js
+versions, point `FNM_DIR` at a user-writable location and run the task
+with `fnm exec`:
+
+``` bash
+docker run --rm -e FNM_DIR=/home/worker/.local/share/fnm quay.io/mynth/worker:26 \
+  sh -c "fnm install 24 && fnm exec --using=24 node --version"
+```
+
 ## Embracing Ubuntu as the Ideal Base for Container Images
 
 In the world of containerization, choosing the right base image is

--- a/examples/worker/Dockerfile
+++ b/examples/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/mynth/worker:26
+FROM quay.io/mynth/worker:dev
 
 # Set up the task project
 WORKDIR /app

--- a/examples/worker/Dockerfile
+++ b/examples/worker/Dockerfile
@@ -1,8 +1,6 @@
 FROM quay.io/mynth/worker:dev
 
-# Set up the task project
 WORKDIR /app
 COPY --chown=worker:worker . ./
 
-# Run a task that uses the node, python, fnm and uv toolchains
 CMD ["node", "task.mjs"]

--- a/examples/worker/Dockerfile
+++ b/examples/worker/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/mynth/worker:26
+
+# Set up the task project
+WORKDIR /app
+COPY --chown=worker:worker . ./
+
+# Run a task that uses the node, python, fnm and uv toolchains
+CMD ["node", "task.mjs"]

--- a/examples/worker/task.mjs
+++ b/examples/worker/task.mjs
@@ -1,0 +1,31 @@
+// Example task that exercises the combined toolchain of the worker
+// image: node orchestrates, while pnpm, fnm, python and uv do the work.
+import { execFileSync } from "node:child_process";
+
+const run = (command, args) =>
+  execFileSync(command, args, { encoding: "utf8" }).trim();
+
+const versions = {
+  node: process.version,
+  npm: run("npm", ["--version"]),
+  pnpm: run("pnpm", ["--version"]),
+  fnm: run("fnm", ["--version"]),
+  python: run("python", ["--version"]),
+  uv: run("uv", ["--version"]),
+  uvx: run("uvx", ["--version"]),
+};
+
+// Run a Python calculation with the uv-managed CPython build
+const result = Number(
+  run("uv", ["run", "python", "-c", "print(sum(range(10)))"]),
+);
+
+console.log(JSON.stringify(versions, null, 2));
+console.log(`sum(range(10)) computed by uv-managed python: ${result}`);
+
+if (result !== 45) {
+  console.error("unexpected python result");
+  process.exit(1);
+}
+
+console.log("worker task completed");

--- a/examples/worker/task.mjs
+++ b/examples/worker/task.mjs
@@ -1,5 +1,5 @@
-// Example task that exercises the combined toolchain of the worker
-// image: node orchestrates, while pnpm, fnm, python and uv do the work.
+// Example task for the worker image: node orchestrates the pnpm, fnm
+// and uv toolchains.
 import { execFileSync } from "node:child_process";
 
 const run = (command, args) =>
@@ -15,7 +15,7 @@ const versions = {
   uvx: run("uvx", ["--version"]),
 };
 
-// Run a Python calculation with the uv-managed CPython build
+// Route the calculation through uv to exercise the managed CPython build
 const result = Number(
   run("uv", ["run", "python", "-c", "print(sum(range(10)))"]),
 );
@@ -24,7 +24,7 @@ console.log(JSON.stringify(versions, null, 2));
 console.log(`sum(range(10)) computed by uv-managed python: ${result}`);
 
 if (result !== 45) {
-  console.error("unexpected python result");
+  console.error(`unexpected python result: ${result}`);
   process.exit(1);
 }
 

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -73,12 +73,18 @@ RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         build-essential \
         libatomic1 \
+        sudo \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     corepack enable && \
     corepack prepare pnpm@11.22.0 --activate && \
     npm install -g node-gyp@13.0.1 turbo@2.10.10
+
+# Passwordless sudo lets the worker user modify its environment at runtime
+RUN echo 'worker ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/worker && \
+    chmod 0440 /etc/sudoers.d/worker && \
+    visudo -cf /etc/sudoers.d/worker
 
 RUN UV_TOOL_DIR=/opt/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
     uv tool install poethepoet==0.48.0

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -1,0 +1,93 @@
+# The worker image combines the toolchains of the node and python images
+# into a single container for running tasks that need both ecosystems.
+
+FROM ubuntu:26.04 AS build
+
+ARG FNM_VERSION=1.39.0
+ARG NODE_VERSION=26.7.0
+# Keep this path identical in all stages: fnm stores the default-version
+# alias as an absolute symlink, so it must resolve to the same location.
+ENV FNM_DIR=/usr/local/share/fnm
+
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+ADD https://github.com/Schniz/fnm/releases/download/v${FNM_VERSION}/fnm-linux.zip .
+
+# hadolint ignore=DL3008
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends ca-certificates unzip libatomic1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    unzip fnm-linux.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/fnm && \
+    rm fnm-linux.zip
+
+RUN fnm install ${NODE_VERSION} && \
+    fnm default ${NODE_VERSION}
+
+ENV PATH=$FNM_DIR/aliases/default/bin:$PATH
+RUN npm install -g corepack@0.35.0 && \
+    npm config set update-notifier false
+
+FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
+
+FROM ubuntu:26.04 AS python
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+
+RUN uv python install 3.14.7 --no-cache
+
+FROM ubuntu:26.04
+COPY --from=build /tini /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
+COPY --from=build /usr/local/bin/fnm /usr/local/bin/fnm
+COPY --from=build /usr/local/share/fnm /usr/local/share/fnm
+COPY --from=uv /uv /uvx /usr/local/bin/
+COPY --from=python /opt/uv/python /opt/uv/python
+
+RUN ln -s /opt/uv/python/cpython-3.14-*/bin/python3.14 /usr/local/bin/python3.14 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python3 && \
+    ln -s /usr/local/bin/python3.14 /usr/local/bin/python && \
+    useradd --create-home --shell /bin/bash worker && \
+    mkdir /app && \
+    chown -R worker:worker /app
+
+ENV FNM_DIR=/usr/local/share/fnm
+ENV PNPM_HOME=/home/worker/.local/share/pnpm
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
+ENV PATH=/app/.venv/bin:$PNPM_HOME:/app/node_modules/.bin:$FNM_DIR/aliases/default/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=only-managed
+
+# Node.js 26 requires libatomic.so.1, so apt runs before corepack/npm
+# hadolint ignore=DL3008
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libatomic1 \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    corepack enable && \
+    corepack prepare pnpm@11.22.0 --activate && \
+    npm install -g node-gyp@13.0.1 turbo@2.10.10
+
+RUN UV_TOOL_DIR=/opt/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
+    uv tool install poethepoet==0.48.0
+
+COPY python/install-uv-app.sh /usr/local/bin/install-uv-app
+RUN chmod +x /usr/local/bin/install-uv-app
+
+# hadolint ignore=DL3066
+USER worker
+ENV NODE_ENV=development
+WORKDIR /app
+RUN npm config set update-notifier false

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -1,6 +1,3 @@
-# The worker image combines the toolchains of the node and python images
-# into a single container for running tasks that need both ecosystems.
-
 FROM ubuntu:26.04 AS build
 
 ARG FNM_VERSION=1.39.0
@@ -28,8 +25,7 @@ RUN fnm install ${NODE_VERSION} && \
     fnm default ${NODE_VERSION}
 
 ENV PATH=$FNM_DIR/aliases/default/bin:$PATH
-RUN npm install -g corepack@0.35.0 && \
-    npm config set update-notifier false
+RUN npm install -g corepack@0.35.0
 
 FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
 


### PR DESCRIPTION
## Summary

- New `worker/worker.Dockerfile` builds **`quay.io/mynth/worker:dev`**: a single image combining the toolchains of the `node` (`26-dev`) and `python` (`dev`) images, intended for running tasks in an isolated environment.
- Tagged `dev` following the python image convention: the tag describes the variant (full tooling) rather than an arbitrary version, and leaves room for a future runtime-only `worker:base`.
- Node.js 26.7.0 managed by `fnm` and Python 3.14.7 managed by `uv` (same versions and install patterns as the existing images), plus `tini` entrypoint, non-root `worker` user, `build-essential`, `corepack`/`pnpm`, `node-gyp`, `turbo`, Poe the Poet and the `install-uv-app` helper.
- The non-root `worker` user has **passwordless `sudo`**, so tasks can modify the container environment at runtime (e.g. `sudo apt-get install` extra packages) — configured via `/etc/sudoers.d/worker` and validated with `visudo -cf` during build.
- `make worker` builds the image; `examples/worker` demonstrates a task using both toolchains (node orchestrating a uv-managed python calculation).
- CI: new `worker.yml` — hadolint on both Dockerfiles, `make worker`, running the example (asserted by its exit code), and tooling/sudo smoke tests that each run in a single container.
- README documents the image, usage, sudo, and switching Node versions with `fnm`.

## Verification (local)

- `hadolint` clean for both new Dockerfiles
- `make worker` builds successfully
- In-container smoke tests: runs as `worker` with `tini` as PID 1; `node v26.7.0`, `npm 11.19.0`, `pnpm 11.22.0`, `fnm 1.39.0` (`fnm ls` shows the default alias), `python 3.14.7`, `uv 0.12.5`, `uvx 0.12.5`, `poe 0.48.0`, `install-uv-app` present
- Passwordless sudo: `sudo -n whoami` → `root`; runtime env modification verified via `sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends jq && jq --version` in a fresh container. System-wide Node.js installs also work: `sudo -E fnm install 24 && fnm exec --using=24 node --version` → `v24.19.0`.
- `uv run python` works outside a project; additional Node versions install via a user-local `FNM_DIR` (`fnm install 24 && fnm exec --using=24 node --version` → `v24.19.0`)
- `docker run --rm worker-example` prints all tool versions and the computed python result (`sum(range(10)) = 45`)
- All of the above re-verified after the cleanup commit; additionally `npm config get update-notifier` → `false` for the `worker` user

## Notes

- The cleanup commit (`305d5a0`) is a behavior-preserving refactor: each CI smoke test now runs in a single container instead of one container per command, the example is asserted by its exit code instead of `tee` + `grep` on a log file, a dead build-stage `npm config set update-notifier false` was removed (it only wrote `/root/.npmrc` in a discarded stage — the final stage still sets it for the runtime user), obvious comments were dropped and the README tag list now reads like the sibling sections.
- Like `node:26-dev`, the first `pnpm` use in a fresh container lets corepack download the pinned pnpm into the user cache (network required) — behavior inherited from the node image pattern.
- The worker image is deliberately not published anywhere yet; publishing to Quay can be added later if/when needed.