### PR TITLE
Add core CLI tools to worker image for AI agent tasks

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -37,7 +37,8 @@ jobs:
           git --version && curl --version | head -n1 &&
           jq --version && rg --version | head -n1 &&
           zip --version | head -n2 && unzip -v | head -n1 &&
-          file --version && pkg-config --version && sqlite3 --version
+          file --version && pkg-config --version && sqlite3 --version &&
+          pandoc --version | head -n1
         '
 
     - name: Check worker user can modify its environment

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -33,7 +33,11 @@ jobs:
         docker run --rm quay.io/mynth/worker:dev sh -c '
           node --version && npm --version && pnpm --version &&
           fnm --version && fnm ls &&
-          python --version && uv --version && uvx --version && poe --version
+          python --version && uv --version && uvx --version && poe --version &&
+          git --version && curl --version | head -n1 &&
+          jq --version && rg --version | head -n1 &&
+          zip --version | head -n2 && unzip -v | head -n1 &&
+          file --version && pkg-config --version && sqlite3 --version
         '
 
     - name: Check worker user can modify its environment

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ by [`uv`](https://docs.astral.sh/uv/), together with the tooling from
 the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
 `install-uv-app`) plus `build-essential` for native modules. It also
 ships the core CLI utilities an AI agent needs to work out of the box:
-`git`, `curl`, `ripgrep`, `jq`, `zip`/`unzip`, `file`, `pkg-config` and
-`sqlite3`. A single tag exists for the `worker` container:
+`git`, `curl`, `ripgrep`, `jq`, `zip`/`unzip`, `file`, `pkg-config`,
+`sqlite3` and `pandoc`. A single tag exists for the `worker` container:
 
 - quay.io/mynth/worker:dev
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ single container with both toolchains side by side. It ships Node.js 26
 managed by [fnm](https://github.com/Schniz/fnm) and Python 3.14 managed
 by [`uv`](https://docs.astral.sh/uv/), together with the tooling from
 the `dev` images (`pnpm`, `node-gyp`, `turbo`, Poe the Poet and
-`install-uv-app`) plus `build-essential` for native modules. A single
-tag exists for the `worker` container:
+`install-uv-app`) plus `build-essential` for native modules. It also
+ships the core CLI utilities an AI agent needs to work out of the box:
+`git`, `curl`, `ripgrep`, `jq`, `zip`/`unzip`, `file`, `pkg-config` and
+`sqlite3`. A single tag exists for the `worker` container:
 
 - quay.io/mynth/worker:dev
 

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -65,11 +65,12 @@ ENV UV_PYTHON_PREFERENCE=only-managed
 
 # Core CLI utilities (git, curl, ripgrep, jq, zip, unzip, file,
 # pkg-config, sqlite3) so tasks have the tooling an AI agent needs
-# out of the box. Node.js 26 requires libatomic.so.1, so apt runs
-# before corepack/npm
-# hadolint ignore=DL3008
+# out of the box. Recommended packages are installed as well so the
+# tools are fully functional out of the box. Node.js 26 requires
+# libatomic.so.1, so apt runs before corepack/npm
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
         build-essential \
         ca-certificates \
         curl \

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -63,13 +63,26 @@ ENV PATH=/app/.venv/bin:$PNPM_HOME:/app/node_modules/.bin:$FNM_DIR/aliases/defau
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
-# Node.js 26 requires libatomic.so.1, so apt runs before corepack/npm
+# Core CLI utilities (git, curl, ripgrep, jq, zip, unzip, file,
+# pkg-config, sqlite3) so tasks have the tooling an AI agent needs
+# out of the box. Node.js 26 requires libatomic.so.1, so apt runs
+# before corepack/npm
 # hadolint ignore=DL3008
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         build-essential \
+        ca-certificates \
+        curl \
+        file \
+        git \
+        jq \
         libatomic1 \
+        pkg-config \
+        ripgrep \
+        sqlite3 \
         sudo \
+        unzip \
+        zip \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/worker/worker.Dockerfile
+++ b/worker/worker.Dockerfile
@@ -64,7 +64,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 # Core CLI utilities (git, curl, ripgrep, jq, zip, unzip, file,
-# pkg-config, sqlite3) so tasks have the tooling an AI agent needs
+# pandoc, pkg-config, sqlite3) so tasks have the tooling an AI agent needs
 # out of the box. Recommended packages are installed as well so the
 # tools are fully functional out of the box. Node.js 26 requires
 # libatomic.so.1, so apt runs before corepack/npm
@@ -78,6 +78,7 @@ RUN apt-get update -qq && \
         git \
         jq \
         libatomic1 \
+        pandoc \
         pkg-config \
         ripgrep \
         sqlite3 \


### PR DESCRIPTION
## Summary

The `worker` image is meant for running tasks in an isolated environment — increasingly that means AI agents doing real work (searching code, fetching dependencies, inspecting artifacts). This PR bakes the core CLI utilities such an agent needs directly into the image, so they are available out of the box instead of requiring a runtime `sudo apt-get install`.

## Tools added (final stage of `worker/worker.Dockerfile`)

| Tool | Purpose | Version in built image |
| --- | --- | --- |
| `ripgrep` (`rg`) | fast code/file search | 15.1.0 |
| `jq` | JSON processing | 1.8.1 |
| `ca-certificates` | TLS trust for `curl`/`git` HTTPS | 20260604 |
| `git` | version control | 2.53.0 |
| `curl` | HTTP client | 8.18.0 |
| `zip` / `unzip` | archive handling | 3.0 / 6.00 |
| `file` | file-type inspection | 5.46 |
| `pkg-config` | build metadata for native deps | 2.5.1 |
| `sqlite3` | local SQL storage/queries | 3.46.1 |
| `pandoc` | universal document converter (Markdown, HTML, DOCX and more) | 3.7.0.2 |

Notes:
- `ca-certificates` and `unzip` previously existed only in the intermediate `build` stage (needed to fetch fnm); they are now installed in the shipped image too.
- Packages are installed **without** `--no-install-recommends`, so recommended packages come along and the tools are fully functional out of the box. That adds 51 packages, notably `openssh-client` (git over SSH), `gnupg`/`gpg` (commit/tag signing), `less` (pager), `manpages`/`manpages-dev`, `tzdata`, `bash-completion` and `fakeroot`.
- `build-essential` (already present) covers compilation; `pkg-config` complements it for locating native libraries.
- `pandoc` comes from the Ubuntu `universe` pocket; with recommends it pulls in `pandoc-data` and adds roughly 200 MB installed.

## Also updated

- `README.md`: worker section now documents the bundled CLI utilities.
- `.github/workflows/worker.yml`: CI tool-availability check extended to the new tools.

## Verification

Built locally with `make build-worker` and ran version + functional checks inside the image as the `worker` user:

- `jq` parsed JSON, `rg` searched a file, `git init`/`commit` worked, `curl` reached `https://api.github.com` over TLS (HTTP/2 200 — cert bundle works), `zip`/`unzip` round-tripped a file, `file` identified a binary, `pkg-config` parsed a `.pc` file via `PKG_CONFIG_PATH`, `sqlite3` evaluated `select 6*7` → `42`.
- `pandoc` converted Markdown to HTML and DOCX (`-f markdown -t html` / `-t docx`), and `file` confirmed the generated DOCX.
- hadolint passes locally on the modified Dockerfile (`hadolint ignore=DL3008,DL3015` on the install step, since DL3015 mandates `--no-install-recommends`).
- The existing example (`examples/worker/task.mjs`) is untouched.
